### PR TITLE
Add a SimpleHkdf variant that uses SimpleHmac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,13 +84,14 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.0"
+version = "0.12.1-pre.0"
 dependencies = [
  "blobby",
  "hex-literal",
  "hmac",
  "sha-1",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -153,3 +154,9 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "zeroize"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"

--- a/hkdf/CHANGELOG.md
+++ b/hkdf/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2022-01-24)
+### Added
+- `SimpleHkdf` mirrors `Hkdf` but using `SimpleHmac`.
+
+
 ## 0.12.0 (2021-12-07)
 ### Changed
 - Bump `hmac` crate dependency to v0.12 and `digest` to v0.10 ([#52])

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.12.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.1-pre.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"
@@ -19,6 +19,7 @@ blobby = "0.3"
 hex-literal = "0.2"
 sha-1 = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
+zeroize = "1.5.0"
 
 [features]
 std = ["hmac/std"]

--- a/hkdf/benches/mod.rs
+++ b/hkdf/benches/mod.rs
@@ -25,3 +25,26 @@ fn hkdf_sha256_8000(b: &mut Bencher) {
     b.iter(|| HkdfSha256::new(Some(&[]), &[]).expand(&[], &mut okm));
     b.bytes = okm.len() as u64;
 }
+
+type SimpleHkdfSha256 = hkdf::SimpleHkdf<sha2::Sha256>;
+
+#[bench]
+fn simple_hkdf_sha256_10(b: &mut Bencher) {
+    let mut okm = vec![0u8; 10];
+    b.iter(|| SimpleHkdfSha256::new(Some(&[]), &[]).expand(&[], &mut okm));
+    b.bytes = okm.len() as u64;
+}
+
+#[bench]
+fn simple_hkdf_sha256_1024(b: &mut Bencher) {
+    let mut okm = vec![0u8; 1024];
+    b.iter(|| SimpleHkdfSha256::new(Some(&[]), &[]).expand(&[], &mut okm));
+    b.bytes = okm.len() as u64;
+}
+
+#[bench]
+fn simple_hkdf_sha256_8000(b: &mut Bencher) {
+    let mut okm = vec![0u8; 8000];
+    b.iter(|| SimpleHkdfSha256::new(Some(&[]), &[]).expand(&[], &mut okm));
+    b.bytes = okm.len() as u64;
+}

--- a/hkdf/tests/tests.rs
+++ b/hkdf/tests/tests.rs
@@ -1,9 +1,10 @@
 use core::iter;
 
 use hex_literal::hex;
-use hkdf::{Hkdf, HkdfExtract};
+use hkdf::{Hkdf, HkdfExtract, SimpleHkdf, SimpleHkdfExtract};
 use sha1::Sha1;
 use sha2::{Sha256, Sha384, Sha512};
+use zeroize::Zeroize;
 
 struct Test<'a> {
     ikm: &'a [u8],
@@ -91,15 +92,27 @@ fn test_rfc5869_sha256() {
         } else {
             Some(&salt[..])
         };
+
         let (prk2, hkdf) = Hkdf::<Sha256>::extract(salt, ikm);
         let mut okm2 = vec![0u8; okm.len()];
         assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
-
         assert_eq!(prk2[..], prk[..]);
         assert_eq!(okm2[..], okm[..]);
 
-        okm2.iter_mut().for_each(|b| *b = 0);
+        okm2.iter_mut().zeroize();
         let hkdf = Hkdf::<Sha256>::from_prk(prk).unwrap();
+        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
+        assert_eq!(okm2[..], okm[..]);
+
+        // Now do the same with SimpleHkdf.
+        okm2.iter_mut().zeroize();
+        let (prk2, hkdf) = SimpleHkdf::<Sha256>::extract(salt, ikm);
+        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
+        assert_eq!(prk2[..], prk[..]);
+        assert_eq!(okm2[..], okm[..]);
+
+        okm2.iter_mut().zeroize();
+        let hkdf = SimpleHkdf::<Sha256>::from_prk(prk).unwrap();
         assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
         assert_eq!(okm2[..], okm[..]);
     }
@@ -188,12 +201,23 @@ fn test_rfc5869_sha1() {
         let (prk2, hkdf) = Hkdf::<Sha1>::extract(salt, ikm);
         let mut okm2 = vec![0u8; okm.len()];
         assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
-
         assert_eq!(prk2[..], prk[..]);
         assert_eq!(okm2[..], okm[..]);
 
-        okm2.iter_mut().for_each(|b| *b = 0);
+        okm2.iter_mut().zeroize();
         let hkdf = Hkdf::<Sha1>::from_prk(prk).unwrap();
+        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
+        assert_eq!(okm2[..], okm[..]);
+
+        // Now do the same with SimpleHkdf.
+        okm2.iter_mut().zeroize();
+        let (prk2, hkdf) = SimpleHkdf::<Sha1>::extract(salt, ikm);
+        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
+        assert_eq!(prk2[..], prk[..]);
+        assert_eq!(okm2[..], okm[..]);
+
+        okm2.iter_mut().zeroize();
+        let hkdf = SimpleHkdf::<Sha1>::from_prk(prk).unwrap();
         assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
         assert_eq!(okm2[..], okm[..]);
     }
@@ -204,6 +228,7 @@ const MAX_SHA256_LENGTH: usize = 255 * (256 / 8); // =8160
 #[test]
 fn test_lengths() {
     let hkdf = Hkdf::<Sha256>::new(None, &[]);
+    let simple_hkdf = SimpleHkdf::<Sha256>::new(None, &[]);
     let mut longest = vec![0u8; MAX_SHA256_LENGTH];
     assert!(hkdf.expand(&[], &mut longest).is_ok());
     // Runtime is O(length), so exhaustively testing all legal lengths
@@ -217,6 +242,12 @@ fn test_lengths() {
         assert!(hkdf.expand(&[], &mut okm).is_ok());
         assert_eq!(okm.len(), length);
         assert_eq!(okm[..], longest[..length]);
+
+        // Now do the same with SimpleHkdf.
+        okm.iter_mut().zeroize();
+        assert!(simple_hkdf.expand(&[], &mut okm).is_ok());
+        assert_eq!(okm.len(), length);
+        assert_eq!(okm[..], longest[..length]);
     }
 }
 
@@ -225,6 +256,11 @@ fn test_max_length() {
     let hkdf = Hkdf::<Sha256>::new(Some(&[]), &[]);
     let mut okm = vec![0u8; MAX_SHA256_LENGTH];
     assert!(hkdf.expand(&[], &mut okm).is_ok());
+
+    // Now do the same with SimpleHkdf.
+    okm.iter_mut().zeroize();
+    let hkdf = SimpleHkdf::<Sha256>::new(Some(&[]), &[]);
+    assert!(hkdf.expand(&[], &mut okm).is_ok());
 }
 
 #[test]
@@ -232,12 +268,22 @@ fn test_max_length_exceeded() {
     let hkdf = Hkdf::<Sha256>::new(Some(&[]), &[]);
     let mut okm = vec![0u8; MAX_SHA256_LENGTH + 1];
     assert!(hkdf.expand(&[], &mut okm).is_err());
+
+    // Now do the same with SimpleHkdf.
+    okm.iter_mut().zeroize();
+    let hkdf = SimpleHkdf::<Sha256>::new(Some(&[]), &[]);
+    assert!(hkdf.expand(&[], &mut okm).is_err());
 }
 
 #[test]
 fn test_unsupported_length() {
     let hkdf = Hkdf::<Sha256>::new(Some(&[]), &[]);
     let mut okm = vec![0u8; 90000];
+    assert!(hkdf.expand(&[], &mut okm).is_err());
+
+    // Now do the same with SimpleHkdf.
+    okm.iter_mut().zeroize();
+    let hkdf = SimpleHkdf::<Sha256>::new(Some(&[]), &[]);
     assert!(hkdf.expand(&[], &mut okm).is_err());
 }
 
@@ -248,6 +294,8 @@ fn test_prk_too_short() {
     let output_len = Sha256::output_size();
     let prk = vec![0; output_len - 1];
     assert!(Hkdf::<Sha256>::from_prk(&prk).is_err());
+    // Now do the same with SimpleHkdf.
+    assert!(SimpleHkdf::<Sha256>::from_prk(&prk).is_err());
 }
 
 #[test]
@@ -256,22 +304,25 @@ fn test_derive_sha1_with_none() {
     let ikm = hex!("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
     let salt = None;
     let info = hex!("");
+    let expected_prk = hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd");
+    let expected_okm = hex!("
+        2c91117204d745f3500d636a62f64f0a
+        b3bae548aa53d423b0d1f27ebba6f5e5
+        673a081d70cce7acfc48
+    ");
+
     let (prk, hkdf) = Hkdf::<Sha1>::extract(salt, &ikm[..]);
     let mut okm = [0u8; 42];
     assert!(hkdf.expand(&info[..], &mut okm).is_ok());
+    assert_eq!(prk[..], expected_prk[..]);
+    assert_eq!(okm[..], expected_okm[..]);
 
-    assert_eq!(
-        prk[..],
-        hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd")[..]
-    );
-    assert_eq!(
-        okm[..],
-        hex!("
-            2c91117204d745f3500d636a62f64f0a
-            b3bae548aa53d423b0d1f27ebba6f5e5
-            673a081d70cce7acfc48
-        ")[..],
-    );
+    // Now do the same with SimpleHkdf.
+    let (prk, hkdf) = Hkdf::<Sha1>::extract(salt, &ikm[..]);
+    let mut okm = [0u8; 42];
+    assert!(hkdf.expand(&info[..], &mut okm).is_ok());
+    assert_eq!(prk[..], expected_prk[..]);
+    assert_eq!(okm[..], expected_okm[..]);
 }
 
 #[test]
@@ -285,6 +336,48 @@ fn test_expand_multi_info() {
     ];
 
     let (_, hkdf_ctx) = Hkdf::<Sha256>::extract(None, b"some ikm here");
+
+    // Compute HKDF-Expand on the concatenation of all the info components
+    let mut oneshot_res = [0u8; 16];
+    hkdf_ctx
+        .expand(&info_components.concat(), &mut oneshot_res)
+        .unwrap();
+
+    // Now iteratively join the components of info_components until it's all 1 component. The value
+    // of HKDF-Expand should be the same throughout
+    let mut num_concatted = 0;
+    let mut info_head = Vec::new();
+
+    while num_concatted < info_components.len() {
+        info_head.extend(info_components[num_concatted]);
+
+        // Build the new input to be the info head followed by the remaining components
+        let input: Vec<&[u8]> = iter::once(info_head.as_slice())
+            .chain(info_components.iter().cloned().skip(num_concatted + 1))
+            .collect();
+
+        // Compute and compare to the one-shot answer
+        let mut multipart_res = [0u8; 16];
+        hkdf_ctx
+            .expand_multi_info(&input, &mut multipart_res)
+            .unwrap();
+        assert_eq!(multipart_res, oneshot_res);
+
+        num_concatted += 1;
+    }
+}
+
+#[test]
+fn test_expand_multi_info_simple() {
+    let info_components = &[
+        &b"09090909090909090909090909090909090909090909"[..],
+        &b"8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a"[..],
+        &b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"[..],
+        &b"4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4"[..],
+        &b"1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"[..],
+    ];
+
+    let (_, hkdf_ctx) = SimpleHkdf::<Sha256>::extract(None, b"some ikm here");
 
     // Compute HKDF-Expand on the concatenation of all the info components
     let mut oneshot_res = [0u8; 16];
@@ -357,6 +450,47 @@ fn test_extract_streaming() {
     }
 }
 
+#[test]
+fn test_extract_streaming_simple() {
+    let ikm_components = &[
+        &b"09090909090909090909090909090909090909090909"[..],
+        &b"8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a"[..],
+        &b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"[..],
+        &b"4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4"[..],
+        &b"1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"[..],
+    ];
+    let salt = b"mysalt";
+
+    // Compute HKDF-Extract on the concatenation of all the IKM components
+    let (oneshot_res, _) = SimpleHkdf::<Sha256>::extract(Some(&salt[..]), &ikm_components.concat());
+
+    // Now iteratively join the components of ikm_components until it's all 1 component. The value
+    // of HKDF-Extract should be the same throughout
+    let mut num_concatted = 0;
+    let mut ikm_head = Vec::new();
+
+    while num_concatted < ikm_components.len() {
+        ikm_head.extend(ikm_components[num_concatted]);
+
+        // Make a new extraction context and build the new input to be the IKM head followed by the
+        // remaining components
+        let mut extract_ctx = SimpleHkdfExtract::<Sha256>::new(Some(&salt[..]));
+        let input = iter::once(ikm_head.as_slice())
+            .chain(ikm_components.iter().cloned().skip(num_concatted + 1));
+
+        // Stream in the IKM input in the chunks specified
+        for ikm in input {
+            extract_ctx.input_ikm(ikm);
+        }
+
+        // Finalize and compare to the one-shot answer
+        let (multipart_res, _) = extract_ctx.finalize();
+        assert_eq!(multipart_res, oneshot_res);
+
+        num_concatted += 1;
+    }
+}
+
 /// Define test
 macro_rules! new_test {
     ($name:ident, $test_name:expr, $hkdf:ty) => {
@@ -401,3 +535,8 @@ new_test!(wycheproof_sha1, "wycheproof-sha1", Hkdf::<Sha1>);
 new_test!(wycheproof_sha256, "wycheproof-sha256", Hkdf::<Sha256>);
 new_test!(wycheproof_sha384, "wycheproof-sha384", Hkdf::<Sha384>);
 new_test!(wycheproof_sha512, "wycheproof-sha512", Hkdf::<Sha512>);
+
+new_test!(wycheproof_sha1_simple, "wycheproof-sha1", SimpleHkdf::<Sha1>);
+new_test!(wycheproof_sha256_simple, "wycheproof-sha256", SimpleHkdf::<Sha256>);
+new_test!(wycheproof_sha384_simple, "wycheproof-sha384", SimpleHkdf::<Sha384>);
+new_test!(wycheproof_sha512_simple, "wycheproof-sha512", SimpleHkdf::<Sha512>);


### PR DESCRIPTION
This works around the `BufferKind = Eager` dependency in `Hmac` and by extension `Hkdf`, allowing us to use `SimpleHkdf<Blake2b512>`, which unblocks https://github.com/mobilecoinfoundation/mobilecoin/issues/1326

Tested: Unit tests, benchmarks, and verified that I can get `mobilecoin` building with `SimpleHkdf<Blake2b512>`.

Benchmarking shows comparable performance:

```
➜  hkdf git:(add-simple) rustup run nightly cargo bench                            git:(add-simple|…4
    Finished bench [optimized] target(s) in 0.01s
     Running unittests (/home/remoun/code/KDFs/target/release/deps/hkdf-8cdf015f5bb74017)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (/home/remoun/code/KDFs/target/release/deps/mod-9f6a42e76a5102f1)

running 6 tests
test hkdf_sha256_10          ... bench:       2,112 ns/iter (+/- 264) = 4 MB/s
test hkdf_sha256_1024        ... bench:      18,406 ns/iter (+/- 1,014) = 55 MB/s
test hkdf_sha256_8000        ... bench:     136,343 ns/iter (+/- 8,361) = 58 MB/s
test simple_hkdf_sha256_10   ... bench:       2,150 ns/iter (+/- 126) = 4 MB/s
test simple_hkdf_sha256_1024 ... bench:      26,807 ns/iter (+/- 2,869) = 38 MB/s
test simple_hkdf_sha256_8000 ... bench:     201,453 ns/iter (+/- 13,266) = 39 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 8.95s
```